### PR TITLE
ci: 更新 .env.production 中的 VITE_BASE_URL

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-VITE_BASE_URL=https://serein.work:8000
+VITE_BASE_URL=https://serein.work


### PR DESCRIPTION
- 移除了 https://serein.work后面的 :8000
- 这个更改确保了生产环境中的 API 请求地址与前端一致